### PR TITLE
fix: missing type on Product

### DIFF
--- a/XaiValidatePublicApiDefinition.yml
+++ b/XaiValidatePublicApiDefinition.yml
@@ -4117,6 +4117,7 @@ components:
                     type: number
                     description: The estimated value of the security.
             Product:
+              type: object
               properties:
                   Key:
                     type: string


### PR DESCRIPTION
- Add type field to Product othewise codegen tools won't interpret this section correctly